### PR TITLE
Removing es6 function format

### DIFF
--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -79,7 +79,7 @@ module.exports = {
     return content.substr(0, indexToInsert) + contentToInsert + content.substr(indexToInsert);
   },
 
-  getGitUserInfo() {
+  getGitUserInfo: function() {
     return {
       email: this.runCommand('git config user.email'),
       username: this.runCommand('git config user.name'),


### PR DESCRIPTION
Trying to install this addon and I get an error on the line I changed below. 

Changing it fixed the addon install. 
