### PR TITLE
fix genie-init: corrects author typo when json.author is missing

### DIFF
--- a/blueprints/genie-init/index.js
+++ b/blueprints/genie-init/index.js
@@ -52,7 +52,7 @@ module.exports = {
       };
     }
 
-    if(json.autho === '') {
+    if(json.author === '') {
       json.author = locals.username + ' <' + locals.email + '>';
     }
 


### PR DESCRIPTION
Hi,

I was looking at your amazing addon and i found a small typing error on genie-init.
I suppose it is. If it's not, can you explain me why ? :)

Thanks !
