### PR TITLE
Replace the ember-cli/lib/ext/promise references with rsvp

### DIFF
--- a/lib/utils/generate-changelog.js
+++ b/lib/utils/generate-changelog.js
@@ -2,11 +2,11 @@
 
 'use strict';
 
-var Promise     = require('ember-cli/lib/ext/promise');
+var RSVP        = require('rsvp');
 var GitHubApi   = require('github');
 
 var github         = new GitHubApi({version: '3.0.0'});
-var compareCommits = Promise.denodeify(github.repos.compareCommits);
+var compareCommits = RSVP.denodeify(github.repos.compareCommits);
 
 module.exports = function generateChangelog(user, repo, version, branch) {
   version = 'v' + version;

--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -6,8 +6,7 @@ var readYaml    = require('yamljs');
 var writeYaml   = require('write-yaml');
 var merge       = require('lodash.merge');
 var runCommand  = require('./run-command');
-var Promise     = require('ember-cli/lib/ext/promise');
-var Blueprint   = require('ember-cli/lib/models/blueprint');
+var Promise     = require('rsvp').Promise;
 
 module.exports = {
   runCommand: runCommand,
@@ -52,6 +51,8 @@ module.exports = {
   },
 
   processBlueprint: function(type, name, options, extras) {
+    // TODO remove this private ember-cli usage - will break in future versions of ember-cli
+    var Blueprint = require('ember-cli/lib/models/blueprint');
     var bluePrint = Blueprint.lookup(name, {
       paths: [ path.resolve(this.path, '../') ]
     });


### PR DESCRIPTION
I also pulled the Blueprint require inside the scope that needs it, which will allow the addon to work with future versions of ember-cli and where dependent addons don't need to use the blueprint functionality.

I validated the change by running `genie:changelog` (linked to an ember-cli 3.4 addon), with success.